### PR TITLE
Hotfix gen 1393

### DIFF
--- a/src/views/components/tabs/Tabs.web.js
+++ b/src/views/components/tabs/Tabs.web.js
@@ -32,6 +32,7 @@ class Tabs extends PureComponent {
     textColor: 'white',
     tabBarSide: 'top',
     testID: 'tabs',
+    initialIndex: 0,
   }
 
   static propTypes = {
@@ -69,6 +70,7 @@ class Tabs extends PureComponent {
     parentRoute: string,
     history: object,
     location: object,
+    initialIndex: number,
   }
 
   state = {
@@ -86,7 +88,7 @@ class Tabs extends PureComponent {
       newPath &&
       newPath !== newState.currentPath
     ) {
-      newState.currentChild = 0;
+      newState.currentChild = props.initialIndex || 0;
       newState.currentPath = newPath;
 
       return newState;

--- a/src/views/components/tabs/Tabs.web.js
+++ b/src/views/components/tabs/Tabs.web.js
@@ -72,6 +72,7 @@ class Tabs extends PureComponent {
   }
 
   state = {
+    currentPath: '', //eslint-disable-line
     currentChild: 0,
   }
 
@@ -79,8 +80,24 @@ class Tabs extends PureComponent {
     const newState = { ...state };
     const hash = dlv( props, 'history.location.hash' );
     const newIndex = parseInt( hash.slice( 1 ), 10 );
+    const newPath = dlv( props, 'history.location.pathname' );
 
-    if ( newIndex && typeof newIndex === 'number' ) {
+    if (
+      newPath &&
+      newPath !== newState.currentPath
+    ) {
+      newState.currentChild = 0;
+      newState.currentPath = newPath;
+
+      return newState;
+    }
+
+    if (
+      newPath &&
+      newPath === newState.currentPath &&
+      newIndex &&
+      typeof newIndex === 'number'
+    ) {
       if ( newIndex !== newState.currentChild ) {
         newState.currentChild = newIndex;
       }


### PR DESCRIPTION
https://outcomelife.atlassian.net/browse/GEN-1393

## Bug Description:

When navigating between pages that have Tab components, the new page will retain the index from the previous page.

## How to Test:

1. On Internmatch, click on 'Internships from the sidebar.
2. Click on 'Process View' tab.
3. Click on 'Interns' from the sidebar. Tabs should reset to first tab on the new page.