### PR TITLE
Hotfix intm 700

### DIFF
--- a/src/utils/types/object/isObject.js
+++ b/src/utils/types/object/isObject.js
@@ -4,6 +4,7 @@ const isObject = ( object, options = {}) => {
   const {
     withProperties, // array
     withProperty, // string
+    isNotEmpty,
   } = options;
 
   /* Ensure a valid object (and not an array - thanks JS!) is given. */
@@ -33,6 +34,12 @@ const isObject = ( object, options = {}) => {
   /* If withProperty is given, ensure it exists inside the object. */
   if ( isString( withProperty )) {
     if ( !object.hasOwnProperty( withProperty )) {
+      return false;
+    }
+  }
+
+  if ( isNotEmpty ) {
+    if ( !isArray( Object.keys( object ), { ofMinLength: 1 })) {
       return false;
     }
   }


### PR DESCRIPTION
https://outcomelife.atlassian.net/browse/INTM-700

## Bug Description:
Form doesn't update values if base entity attributes aren't received at the same time as the base entity itself. This means that when the check is made, the attributes are an empty object `{}`, and thus were passing `null` checks.

Added a check to see if the attributes are present when checking for missing base entities.

## How to Test:
1) Click on Internships, and find an application which is in the 'Interviews' bucket.
2) Click on the card dropdown and click 'Make Offer'.
3) Check if the base entity attributes such as Name have prefilled.
4) Repeat at least 20 times. This error seems to be caused when base entities messages are slightly delayed.