### PR TITLE
change the env variable name for up mode

### DIFF
--- a/src/utils/api/Api.js
+++ b/src/utils/api/Api.js
@@ -116,7 +116,15 @@ class Api {
   }
 
   getKeycloakConfig = () => {
-    let initUrl = process.env.ENV_GENNY_BRIDGE_URL;
+    let initUrl;
+
+    if ( process.env.NODE_ENV === 'development' ) {
+      initUrl = process.env.ENV_GENNY_INIT_URL;
+    }
+
+    else {
+      initUrl = process.env.ENV_GENNY_BRIDGE_URL;
+    }
 
     /* Default to the env var if set, otherwise use the current URL as the init URL. */
     if ( !initUrl ) {


### PR DESCRIPTION
# Bug Description 
while running in up mode v3 was picking up the wrong environment variable Name while it should be picking up `ENV_GENNY_INIT_URL` 

#Warning 
Before testing this please ask me for the environment variables i cannot paste those here for security reasons. 

