### PR TITLE
Hotfix INTM 745

### DIFF
--- a/src/views/layout/Layout.web.js
+++ b/src/views/layout/Layout.web.js
@@ -180,6 +180,12 @@ class Layout extends PureComponent {
         this.props.layout.setSidebarProps( sidebarProps );
         this.props.layout.setSidebarVisibility( true );
 
+        if (
+          sidebarProps.defaultOpen !== false
+        ) {
+          this.props.layout.setSidebarOpen();
+        }
+
         if ( this.state.unableToFindSidebar )
           this.setState({ unableToFindSidebar: false });
       }
@@ -228,6 +234,12 @@ class Layout extends PureComponent {
       if ( sidebarRightProps && Object.keys( sidebarRightProps ).length > 0 ) {
         this.props.layout.setSidebarRightVisibility( true );
         this.props.layout.setSidebarRightProps( sidebarRightProps );
+
+        if (
+          sidebarRightProps.defaultOpen
+        ) {
+          this.props.layout.setSidebarRightOpen();
+        }
 
         if ( this.state.unableToFindSidebarRight )
           this.setState({ unableToFindSidebarRight: false });

--- a/src/views/layout/provider/LayoutProvider.js
+++ b/src/views/layout/provider/LayoutProvider.js
@@ -90,6 +90,18 @@ class LayoutProvider extends Component {
     );
   }
 
+  setSidebarOpen = () => {
+    store.dispatch(
+      actions.openSidebar( 'left' )
+    );
+  }
+
+  setSidebarRightOpen = () => {
+    store.dispatch(
+      actions.openSidebar( 'right' )
+    );
+  }
+
   setTitle = title => {
     this.setState({ title });
   }
@@ -125,6 +137,8 @@ class LayoutProvider extends Component {
     setHeaderProps: this.setHeaderProps,
     setSidebarProps: this.setSidebarProps,
     setSidebarRightProps: this.setSidebarRightProps,
+    setSidebarOpen: this.setSidebarOpen,
+    setSidebarRightOpen: this.setSidebarRightOpen,
     showSidebar: false,
     showSidebarRight: false,
     showHeader: false,


### PR DESCRIPTION
# Issue https://outcomelife.atlassian.net/browse/INTM-745

# Description:
Sidebar defaults to close.

# How To Test
1) Go to any genny project where the main sidebar is being used.
2) Sidebar on the left side should be open on page load.
3) Go to 'sidebar.default' and add the line `"defaultOpen": false` to the top level object.
4) Reload layouts, and the sidebar should be closed.