### PR TITLE
attached store object to window

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/first */
 import 'nprogress/nprogress.css';
 import './polyfills';
-import React from 'react';
+import React, { Component } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import App from './views/app';
 import { LayoutProvider } from './views/layout';
@@ -18,20 +18,38 @@ console.disableYellowBox = true; // eslint-disable-line no-console
 // }
 // /* ------------------------ */
 
-const Root = () => (
-  <ErrorBoundary>
-    <ReduxProvider store={store}>
-      <VertxProvider>
-        <ThemeProvider>
-          <LayoutProvider>
-            <GoogleProvider>
-              <App />
-            </GoogleProvider>
-          </LayoutProvider>
-        </ThemeProvider>
-      </VertxProvider>
-    </ReduxProvider>
-  </ErrorBoundary>
-);
+class Root extends Component {
+  componentDidMount() {
+    this.attachStoreToWindow();
+  }
+
+  componentDidUpdate() {
+    this.attachStoreToWindow();
+  }
+
+  attachStoreToWindow() {
+    const storeFromRedux = store.getState();
+
+    return storeFromRedux;
+  }
+
+  render() {
+    return (
+      <ErrorBoundary>
+        <ReduxProvider store={store}>
+          <VertxProvider>
+            <ThemeProvider>
+              <LayoutProvider>
+                <GoogleProvider>
+                  <App />
+                </GoogleProvider>
+              </LayoutProvider>
+            </ThemeProvider>
+          </VertxProvider>
+        </ReduxProvider>
+      </ErrorBoundary>
+    );
+  }
+}
 
 export default Root;

--- a/src/Root.js
+++ b/src/Root.js
@@ -30,7 +30,11 @@ class Root extends Component {
   attachStoreToWindow() {
     const storeFromRedux = store.getState();
 
-    return ( window.storeFromRedux = storeFromRedux );
+    if ( typeof window !== 'undefined' ) {
+      return ( window.storeFromRedux = storeFromRedux );
+    }
+
+    return null;
   }
 
   render() {

--- a/src/Root.js
+++ b/src/Root.js
@@ -12,10 +12,10 @@ import './utils/layouts-dev';
 console.disableYellowBox = true; // eslint-disable-line no-console
 
 // // /* --- ADDED FOR LOCAL LAYOUT DEV --- */
-if ( !this.f ) {
-  this.f = true;
-  global.LayoutsDev.load( 'internmatch-new' );
-}
+// if ( !this.f ) {
+//   this.f = true;
+//   global.LayoutsDev.load( 'internmatch-new' );
+// }
 // /* ------------------------ */
 
 class Root extends Component {

--- a/src/Root.js
+++ b/src/Root.js
@@ -12,10 +12,10 @@ import './utils/layouts-dev';
 console.disableYellowBox = true; // eslint-disable-line no-console
 
 // // /* --- ADDED FOR LOCAL LAYOUT DEV --- */
-// if ( !this.f ) {
-//   this.f = true;
-//   global.LayoutsDev.load( 'internmatch-new' );
-// }
+if ( !this.f ) {
+  this.f = true;
+  global.LayoutsDev.load( 'internmatch-new' );
+}
 // /* ------------------------ */
 
 class Root extends Component {
@@ -30,7 +30,7 @@ class Root extends Component {
   attachStoreToWindow() {
     const storeFromRedux = store.getState();
 
-    return storeFromRedux;
+    return ( window.storeFromRedux = storeFromRedux );
   }
 
   render() {

--- a/src/Root.js
+++ b/src/Root.js
@@ -18,25 +18,11 @@ console.disableYellowBox = true; // eslint-disable-line no-console
 // }
 // /* ------------------------ */
 
+if ( typeof window !== 'undefined' ) {
+  window.store = store;
+}
+
 class Root extends Component {
-  componentDidMount() {
-    this.attachStoreToWindow();
-  }
-
-  componentDidUpdate() {
-    this.attachStoreToWindow();
-  }
-
-  attachStoreToWindow() {
-    const storeFromRedux = store.getState();
-
-    if ( typeof window !== 'undefined' ) {
-      return ( window.storeFromRedux = storeFromRedux );
-    }
-
-    return null;
-  }
-
   render() {
     return (
       <ErrorBoundary>

--- a/src/Root.js
+++ b/src/Root.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/first */
 import 'nprogress/nprogress.css';
 import './polyfills';
-import React, { Component } from 'react';
+import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import App from './views/app';
 import { LayoutProvider } from './views/layout';
@@ -22,24 +22,20 @@ if ( typeof window !== 'undefined' ) {
   window.store = store;
 }
 
-class Root extends Component {
-  render() {
-    return (
-      <ErrorBoundary>
-        <ReduxProvider store={store}>
-          <VertxProvider>
-            <ThemeProvider>
-              <LayoutProvider>
-                <GoogleProvider>
-                  <App />
-                </GoogleProvider>
-              </LayoutProvider>
-            </ThemeProvider>
-          </VertxProvider>
-        </ReduxProvider>
-      </ErrorBoundary>
-    );
-  }
-}
+const Root = () => (
+  <ErrorBoundary>
+    <ReduxProvider store={store}>
+      <VertxProvider>
+        <ThemeProvider>
+          <LayoutProvider>
+            <GoogleProvider>
+              <App />
+            </GoogleProvider>
+          </LayoutProvider>
+        </ThemeProvider>
+      </VertxProvider>
+    </ReduxProvider>
+  </ErrorBoundary>
+);
 
 export default Root;


### PR DESCRIPTION
#ChangeLog 
1. Attached the whole store to window 

# How to test 

1. Open up console an then type `store.getState()` you should be able to see the whole store

## Why is this needed ? 

This is required for the tests to access the store for example: to check whether a Baseentity exists or not. 