### PR TITLE
show codes set from local storage and persist

### DIFF
--- a/src/views/components/tooltip/testid-tooltip/TestIdTooltip.js
+++ b/src/views/components/tooltip/testid-tooltip/TestIdTooltip.js
@@ -2,32 +2,51 @@ import React, { Component } from 'react';
 import { Dimensions } from 'react-native-web';
 import { string, node } from 'prop-types';
 import Tooltip from '../Tooltip';
+import Storage from '../../../../utils/storage';
 
 class TestIdTooltip extends Component {
   static defaultProps = {
     id: 'test-id',
-  }
+  };
 
   static propTypes = {
     id: string,
     children: node,
+  };
+
+  // persist the showcodes on localstorgae
+  async persistCodes() {
+    const { children } = this.props;
+    let isDebugMode;
+
+    if ( typeof window === 'object' ) {
+      isDebugMode = window.originalQueryParams.showcodes;
+    }
+
+    const code = await Storage.get( 'showcodes' );
+
+    if ( code === true || code === 'true' ) {
+      isDebugMode = true;
+    } else {
+      isDebugMode = false;
+    }
+
+    if ( !isDebugMode ) {
+      return children;
+    }
   }
 
   handleMouseOver = () => {
     // eslint-disable-next-line no-console
     console.warn( 'TestId:', this.props.id );
-  }
+  };
 
   render() {
     const { id, children } = this.props;
 
     const dimensions = Dimensions.get( 'window' );
 
-    const isDebugMode = window.originalQueryParams.showcodes;
-
-    if ( !isDebugMode ) {
-      return children;
-    }
+    this.persistCodes();
 
     return (
       <Tooltip


### PR DESCRIPTION
# Changelog 
Peristed showcodes to `localstorage` 


# How to test ? 
1. goto `localhost:3000/home?showcodes=true`
2. hover over hamburger menu it should display the test id or any other components which has testid 
